### PR TITLE
Add merge workflow w/ --allow-unrelated-histories flag in an attempt to fix 'fatal: refusing to merge unrelated histories'.

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           git fetch
           git checkout main
-          git merge dev
+          git merge --allow-unrelated-histories dev
           git push origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**[see commits]**