### PR TITLE
Feature/update seller type

### DIFF
--- a/src/config/docs/SellersSchema.yml
+++ b/src/config/docs/SellersSchema.yml
@@ -35,7 +35,7 @@ components:
             example: This is a sample seller description.
           seller_type:
             type: string
-            example: Pioneer
+            example: Real Merchant - actively selling
           image:
             type: string
             example: http://example.com/image.jpg
@@ -90,7 +90,7 @@ components:
           example: This is a sample seller description.
         seller_type:
           type: string
-          example: Pioneer
+          example: Real merchant - not currently selling 
         image:
           type: string
           example: http://example.com/image.jpg
@@ -160,7 +160,7 @@ components:
               example: This is a sample seller description.
             seller_type:
               type: string
-              example: Pioneer
+              example: Test seller
             image:
               type: string
               example: http://example.com/image.jpg
@@ -218,7 +218,7 @@ components:
               example: This is a sample seller description.
             seller_type:
               type: string
-              example: Pioneer
+              example: Test seller
             image:
               type: string
               example: http://example.com/image.jpg

--- a/src/config/docs/enum/SellerType.yml
+++ b/src/config/docs/enum/SellerType.yml
@@ -3,7 +3,7 @@ components:
     SellerType:
       type: string
       enum:
-        - Active seller
-        - Inactive seller
-        - Test seller
+        - activeSeller
+        - inactiveSeller
+        - testSeller
       description: The type of seller.

--- a/src/config/docs/enum/SellerType.yml
+++ b/src/config/docs/enum/SellerType.yml
@@ -3,8 +3,7 @@ components:
     SellerType:
       type: string
       enum:
-        - Pioneer
-        - Currently Not Selling
-        - Test Seller
-        - Other
+        - Active seller
+        - Inactive seller
+        - Test seller
       description: The type of seller.

--- a/src/models/Seller.ts
+++ b/src/models/Seller.ts
@@ -1,65 +1,67 @@
-import mongoose, { Schema, Types } from "mongoose";
+  import mongoose, { Schema, Types } from "mongoose";
 
-import { ISeller } from "../types";
+  import { ISeller } from "../types";
+  import { SellerType } from "./enums/sellerType";
 
-const sellerSchema = new Schema<ISeller>(
-  {
-    seller_id: {
-      type: String,
-      required: true,
-      unique: true,
-    },
-    name: {
-      type: String,
-      required: true,
-    },
-    seller_type: {
-      type: String,
-      required: true,
-      default: 'Pioneer',
-    },
-    description: {
-      type: String,
-      required: false,
-    },
-    image: {
-      type: String,
-      required: false,
-    },
-    address: {
-      type: String,
-      required: false,
-    },
-    average_rating: {
-      type: Types.Decimal128,
-      required: true,
-      default: 5.0,
-    },    
-    sell_map_center: {
-      type: {
+  const sellerSchema = new Schema<ISeller>(
+    {
+      seller_id: {
         type: String,
-        enum: ['Point'],
         required: true,
-        default: 'Point',
+        unique: true,
       },
-      coordinates: {
-        type: [Number],
+      name: {
+        type: String,
         required: true,
-        default: [0, 0]
       },
+      seller_type: {
+        type: String,
+        enum: Object.values(SellerType),
+        required: true,
+        default: SellerType.Test,
+      },
+      description: {
+        type: String,
+        required: false,
+      },
+      image: {
+        type: String,
+        required: false,
+      },
+      address: {
+        type: String,
+        required: false,
+      },
+      average_rating: {
+        type: Types.Decimal128,
+        required: true,
+        default: 5.0,
+      },    
+      sell_map_center: {
+        type: {
+          type: String,
+          enum: ['Point'],
+          required: true,
+          default: 'Point',
+        },
+        coordinates: {
+          type: [Number],
+          required: true,
+          default: [0, 0]
+        },
+      },
+      order_online_enabled_pref: {
+        type: Boolean,
+        required: false,
+      }
     },
-    order_online_enabled_pref: {
-      type: Boolean,
-      required: false,
-    }
-  },
-  { timestamps: true } // Adds timestamps to track creation and update times
-);
+    { timestamps: true } // Adds timestamps to track creation and update times
+  );
 
-// Creating a 2dsphere index for the sell_map_center field
-sellerSchema.index({ 'sell_map_center.coordinates': '2dsphere' });
+  // Creating a 2dsphere index for the sell_map_center field
+  sellerSchema.index({ 'sell_map_center.coordinates': '2dsphere' });
 
-// Creating the Seller model from the schema
-const Seller = mongoose.model<ISeller>("Seller", sellerSchema);
+  // Creating the Seller model from the schema
+  const Seller = mongoose.model<ISeller>("Seller", sellerSchema);
 
-export default Seller;
+  export default Seller;

--- a/src/models/enums/sellerType.ts
+++ b/src/models/enums/sellerType.ts
@@ -1,7 +1,6 @@
 export enum SellerType {
-    Active = 'active',
-    Inactive = 'inactive',
-    Test = 'test',
-    Other = 'other'
+    Active = 'Active seller',
+    Inactive = 'Inactive seller',
+    Test = 'Test seller'
   }
   

--- a/src/models/enums/sellerType.ts
+++ b/src/models/enums/sellerType.ts
@@ -1,0 +1,7 @@
+export enum SellerType {
+    Active = 'active',
+    Inactive = 'inactive',
+    Test = 'test',
+    Other = 'other'
+  }
+  

--- a/src/models/enums/sellerType.ts
+++ b/src/models/enums/sellerType.ts
@@ -1,6 +1,6 @@
 export enum SellerType {
-    Active = 'Active seller',
-    Inactive = 'Inactive seller',
-    Test = 'Test seller'
+    Active = 'activeSeller',
+    Inactive = 'inactiveSeller',
+    Test = 'testSeller'
   }
   

--- a/src/routes/seller.routes.ts
+++ b/src/routes/seller.routes.ts
@@ -23,7 +23,12 @@ import upload from "../utils/multer";
  *           description: Description of the seller
  *         seller_type:
  *           type: string
- *           description: Type of the seller
+ *           description: Type of the seller (active, inactive, test, other) // Update description here
+ *           enum:
+ *             - active
+ *             - inactive
+ *             - test
+ *             - other
  *         image:
  *           type: string
  *           description: Image of the seller

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -3,6 +3,7 @@ import User from "../models/User";
 import UserSettings from "../models/UserSettings";
 import { getUserSettingsById } from "./userSettings.service";
 import { ISeller, IUser, IUserSettings, ISellerWithSettings } from "../types";
+import { SellerType } from '../models/enums/sellerType'
 
 import logger from "../config/loggingConfig";
 
@@ -38,9 +39,9 @@ export const getAllSellers = async (
   try {
     let sellers: ISeller[];
 
-    // always apply this condition to exclude 'CurrentlyNotSelling' sellers
-    const baseCriteria = { seller_type: { $ne: 'CurrentlyNotSelling' } };
-
+    // always apply this condition to exclude 'Inactive' (was 'CurrentlyNotSelling') sellers
+    const baseCriteria = { seller_type: { $ne: SellerType.Inactive } };
+    
     // if search_query is provided, add search conditions
     const searchCriteria = search_query
       ? {
@@ -106,6 +107,8 @@ export const getSingleSellerById = async (seller_id: string): Promise<ISeller | 
 
 export const registerOrUpdateSeller = async (sellerData: ISeller, authUser: IUser): Promise<ISeller> => {
   try {
+    console.log('Received Payload:', sellerData); // Log the incoming seller data
+
     let seller = await Seller.findOne({ seller_id: authUser.pi_uid }).exec();
 
     if (seller) {

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -1,11 +1,10 @@
 import Seller from "../models/Seller";
 import User from "../models/User";
-import UserSettings from "../models/UserSettings";
 import { getUserSettingsById } from "./userSettings.service";
 import { ISeller, IUser, IUserSettings, ISellerWithSettings } from "../types";
+import UserSettings from "../models/UserSettings";
 import { SellerType } from '../models/enums/sellerType'
 
-import mongoose from "mongoose";
 import logger from "../config/loggingConfig";
 
 // Helper function to get settings for all sellers and merge them into seller objects
@@ -40,7 +39,7 @@ export const getAllSellers = async (
   try {
     let sellers: ISeller[];
 
-    // always apply this condition to exclude 'Inactive' (was 'CurrentlyNotSelling') sellers
+    // always apply this condition to exclude 'Inactive sellers'
     const baseCriteria = { seller_type: { $ne: SellerType.Inactive } };
     
     // if search_query is provided, add search conditions

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import { Document, Types } from "mongoose";
 
 import { RatingScale } from "./models/enums/ratingScale";
 import { TrustMeterScale } from "./models/enums/trustMeterScale";
+import { SellerType } from "./models/enums/sellerType";
 
 export interface IUser extends Document {
   pi_uid: string;
@@ -26,7 +27,7 @@ export interface IUserSettings extends Document {
 export interface ISeller extends Document {
   seller_id: string;
   name: string;
-  seller_type: string;
+  seller_type: SellerType;
   description: string;
   image?: string;
   address?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { Document, Types } from "mongoose";
 import { RatingScale } from "./models/enums/ratingScale";
-import { TrustMeterScale } from "./models/enums/trustMeterScale";
 import { SellerType } from "./models/enums/sellerType";
+import { TrustMeterScale } from "./models/enums/trustMeterScale";
 
 export interface IUser extends Document {
   pi_uid: string;

--- a/test/services/seller.service.spec.ts
+++ b/test/services/seller.service.spec.ts
@@ -5,8 +5,8 @@ import { getAllSellers } from '../../src/services/seller.service';
 import Seller from '../../src/models/Seller';
 import UserSettings from '../../src/models/UserSettings';
 import { ISeller, ISellerWithSettings, IUserSettings } from '../../src/types';
-import { TrustMeterScale } from '../../src/models/enums/trustMeterScale';
 import { SellerType } from '../../src/models/enums/sellerType';
+import { TrustMeterScale } from '../../src/models/enums/trustMeterScale';
 
 let mongoServer: MongoMemoryServer;
 
@@ -15,35 +15,35 @@ const mockSellers = [
     seller_id: '0a0a0a-0a0a-0a0a',
     name: 'Test Seller 1',
     description: 'Test Seller 1 Description',
-    seller_type: SellerType.Test, // Updated enum value for 'Test seller'
+    seller_type: SellerType.Test,
     sell_map_center: { type: 'Point', coordinates: [-74.0060, 40.7128] }
   },
   {
     seller_id: '0b0b0b-0b0b-0b0b',
     name: 'Test Vendor 2',
     description: 'Test Vendor 2 Description',
-    seller_type: SellerType.Inactive, // Updated to 'Real merchant - not currently selling'
+    seller_type: SellerType.Inactive,
     sell_map_center: { type: 'Point', coordinates: [-118.2437, 34.0522] }
   },
   {
     seller_id: '0c0c0c-0c0c-0c0c',
     name: 'Test Vendor 3',
     description: 'Test Vendor 3 Description',
-    seller_type: SellerType.Active, // Updated enum value for 'Real merchant - actively selling'
+    seller_type: SellerType.Active,
     sell_map_center: { type: 'Point', coordinates: [-87.6298, 41.8781] }
   },
   {
     seller_id: '0d0d0d-0d0d-0d0d',
     name: 'Test Seller 4',
     description: 'Test Seller 4 Description',
-    seller_type: SellerType.Inactive, // Updated to 'Real merchant - not currently selling'
+    seller_type: SellerType.Inactive,
     sell_map_center: { type: 'Point', coordinates: [-122.4194, 37.7749] }
   },
   {
     seller_id: '0e0e0e-0e0e-0e0e',
     name: 'Test Vendor 5',
     description: 'Test Vendor 5 Description',
-    seller_type: SellerType.Test, // Updated enum value for 'Test seller'
+    seller_type: SellerType.Test,
     sell_map_center: { type: 'Point', coordinates: [-95.3698, 29.7604] }
   }
 ] as ISeller[];
@@ -139,7 +139,7 @@ afterAll(async () => {
 
 describe('getAllSellers function', () => {
   it('should fetch all sellers when all parameters are empty', async () => {
-    // filter seller records to exclude those with seller_type "CurrentlyNotSelling"
+    // filter seller records to exclude those with seller_type "Inactive"
     const expectedMockSellers = mockSellers.filter(
       seller => seller.seller_type !== SellerType.Inactive
     );
@@ -154,7 +154,7 @@ describe('getAllSellers function', () => {
 
   it('should fetch all applicable sellers when search query is provided and origin + radius params are empty', async () => {
     /* filter seller records to include those with description "Vendor" 
-       + exclude those with seller_type "CurrentlyNotSelling" */
+       + exclude those with seller_type "Inactive" */
     const expectedMockSellers = mockSellers.filter(
       seller => seller.description.includes('Vendor') && 
       seller.seller_type !== SellerType.Inactive
@@ -169,7 +169,7 @@ describe('getAllSellers function', () => {
   });
 
   it('should fetch all applicable sellers when origin + radius are provided and search query param is empty', async () => { 
-    /* filter seller records to exclude those with seller_type "CurrentlyNotSelling" 
+    /* filter seller records to exclude those with seller_type "Inactive"
        + include those with sell_map_center within geospatial radius */
     const expectedMockSellers = mockSellers.filter(
       seller => seller.seller_type !== SellerType.Inactive &&
@@ -187,7 +187,7 @@ describe('getAllSellers function', () => {
   });
 
   it('should fetch all applicable sellers when all parameters are provided', async () => { 
-    /* filter seller records to exclude those with seller_type "CurrentlyNotSelling" 
+    /* filter seller records to exclude those with seller_type "Inactive"
        + include those with description "Vendor"
        + include those with sell_map_center within geospatial radius */
     const expectedMockSellers = mockSellers.filter(

--- a/test/services/seller.service.spec.ts
+++ b/test/services/seller.service.spec.ts
@@ -6,6 +6,7 @@ import Seller from '../../src/models/Seller';
 import UserSettings from '../../src/models/UserSettings';
 import { ISeller, ISellerWithSettings, IUserSettings } from '../../src/types';
 import { TrustMeterScale } from '../../src/models/enums/trustMeterScale';
+import { SellerType } from '../../src/models/enums/sellerType';
 
 let mongoServer: MongoMemoryServer;
 
@@ -14,35 +15,35 @@ const mockSellers = [
     seller_id: '0a0a0a-0a0a-0a0a',
     name: 'Test Seller 1',
     description: 'Test Seller 1 Description',
-    seller_type: 'TestSeller',
+    seller_type: SellerType.Test, // Updated enum value for 'Test seller'
     sell_map_center: { type: 'Point', coordinates: [-74.0060, 40.7128] }
   },
   {
     seller_id: '0b0b0b-0b0b-0b0b',
     name: 'Test Vendor 2',
     description: 'Test Vendor 2 Description',
-    seller_type: 'CurrentlyNotSelling',
+    seller_type: SellerType.Inactive, // Updated to 'Real merchant - not currently selling'
     sell_map_center: { type: 'Point', coordinates: [-118.2437, 34.0522] }
   },
   {
     seller_id: '0c0c0c-0c0c-0c0c',
     name: 'Test Vendor 3',
     description: 'Test Vendor 3 Description',
-    seller_type: 'Pioneer',
+    seller_type: SellerType.Active, // Updated enum value for 'Real merchant - actively selling'
     sell_map_center: { type: 'Point', coordinates: [-87.6298, 41.8781] }
   },
   {
     seller_id: '0d0d0d-0d0d-0d0d',
     name: 'Test Seller 4',
     description: 'Test Seller 4 Description',
-    seller_type: 'CurrentlyNotSelling',
+    seller_type: SellerType.Inactive, // Updated to 'Real merchant - not currently selling'
     sell_map_center: { type: 'Point', coordinates: [-122.4194, 37.7749] }
   },
   {
     seller_id: '0e0e0e-0e0e-0e0e',
     name: 'Test Vendor 5',
     description: 'Test Vendor 5 Description',
-    seller_type: 'TestSeller',
+    seller_type: SellerType.Test, // Updated enum value for 'Test seller'
     sell_map_center: { type: 'Point', coordinates: [-95.3698, 29.7604] }
   }
 ] as ISeller[];
@@ -140,7 +141,7 @@ describe('getAllSellers function', () => {
   it('should fetch all sellers when all parameters are empty', async () => {
     // filter seller records to exclude those with seller_type "CurrentlyNotSelling"
     const expectedMockSellers = mockSellers.filter(
-      seller => seller.seller_type !== 'CurrentlyNotSelling'
+      seller => seller.seller_type !== SellerType.Inactive
     );
 
     const result = await getAllSellers();
@@ -156,7 +157,7 @@ describe('getAllSellers function', () => {
        + exclude those with seller_type "CurrentlyNotSelling" */
     const expectedMockSellers = mockSellers.filter(
       seller => seller.description.includes('Vendor') && 
-      seller.seller_type !== 'CurrentlyNotSelling'
+      seller.seller_type !== SellerType.Inactive
     );
 
     const result = await getAllSellers(undefined, undefined, 'Vendor');
@@ -171,7 +172,7 @@ describe('getAllSellers function', () => {
     /* filter seller records to exclude those with seller_type "CurrentlyNotSelling" 
        + include those with sell_map_center within geospatial radius */
     const expectedMockSellers = mockSellers.filter(
-      seller => seller.seller_type !== 'CurrentlyNotSelling' &&
+      seller => seller.seller_type !== SellerType.Inactive &&
       seller.sell_map_center.type === 'Point' &&
       seller.sell_map_center.coordinates[0] === -74.0060 &&
       seller.sell_map_center.coordinates[1] === 40.7128
@@ -190,7 +191,7 @@ describe('getAllSellers function', () => {
        + include those with description "Vendor"
        + include those with sell_map_center within geospatial radius */
     const expectedMockSellers = mockSellers.filter(
-      seller => seller.seller_type !== 'CurrentlyNotSelling' &&
+      seller => seller.seller_type !== SellerType.Inactive &&
       seller.description.includes('Vendor') &&
       seller.sell_map_center.type === 'Point' &&
       seller.sell_map_center.coordinates[0] === -74.0060 &&


### PR DESCRIPTION
### Update Seller Type Options and Backend Logic

**In this PR we have updated the seller_type field to use predefined options instead of free text. The changes**


Key changes:

- Replacing the old seller type values with "active", "inactive", "test", and "other".

- Updating the backend logic to support these new options.

- Adjusting Swagger documentation to reflect the changes.

- Ensuring validation and filtering align with the new values.

These updates have been tested and confirmed through browser logs, showing correct values for the new seller types.