### PR TITLE
Feature/email phone seller registration

### DIFF
--- a/src/config/docs/SellersSchema.yml
+++ b/src/config/docs/SellersSchema.yml
@@ -100,8 +100,6 @@ components:
           example: This is a sample seller description.
         seller_type:
           $ref: '/api/docs/enum/SellerType.yml#/components/schemas/SellerType'
-            seller_type:
-            $ref: '/api/docs/enum/SellerType.yml#/components/schemas/SellerType'
         email:
           oneOf:
             - type: string

--- a/src/config/docs/SellersSchema.yml
+++ b/src/config/docs/SellersSchema.yml
@@ -35,6 +35,16 @@ components:
             example: This is a sample seller description.
           seller_type:
             $ref: '/api/docs/enum/SellerType.yml#/components/schemas/SellerType'
+          email:
+            oneOf:
+              - type: string
+              - type: "null"
+            example: null
+          phone_number:
+            oneOf:
+              - type: string
+              - type: "null"
+            example: null
           address:
             type: string
             example: 1234 Test St, Test City, SC 12345
@@ -90,6 +100,18 @@ components:
           example: This is a sample seller description.
         seller_type:
           $ref: '/api/docs/enum/SellerType.yml#/components/schemas/SellerType'
+            seller_type:
+            $ref: '/api/docs/enum/SellerType.yml#/components/schemas/SellerType'
+        email:
+          oneOf:
+            - type: string
+            - type: "null"
+          example: null
+        phone_number:
+          oneOf:
+            - type: string
+            - type: "null"
+          example: null
         address:
           type: string
           example: 1234 Test St, Test City, SC 12345
@@ -155,6 +177,16 @@ components:
             name:
               type: string
               example: Test Seller
+            email:
+              oneOf:
+                - type: string
+                - type: "null"
+              example: null
+            phone_number:
+              oneOf:
+                - type: string
+                - type: "null"
+              example: null
             description:
               type: string
               example: This is a sample seller description.
@@ -207,6 +239,16 @@ components:
         name:
           type: string
           example: Test Seller
+        email:
+          oneOf:
+            - type: string
+            - type: "null"
+          example: null
+        phone_number:
+          oneOf:
+            - type: string
+            - type: "null"
+          example: null
         description:
           type: string
           example: This is a sample seller description.
@@ -257,6 +299,16 @@ components:
             name:
               type: string
               example: Test Seller
+            email:
+              oneOf:
+                - type: string
+                - type: "null"
+              example: null
+            phone_number:
+              oneOf:
+                - type: string
+                - type: "null"
+              example: null
             description:
               type: string
               example: This is a sample seller description.

--- a/src/config/docs/UserPreferencesSchema.yml
+++ b/src/config/docs/UserPreferencesSchema.yml
@@ -9,12 +9,6 @@ components:
         user_name:
           type: string
           example: Test User
-        email:
-          type: string
-          example: test_user_preferences@example.com
-        phone_number:
-          type: number
-          example: 123456789
         image:
           type: string
           format: binary
@@ -55,12 +49,6 @@ components:
         user_name:
           type: string
           example: Test User
-        email:
-          type: string
-          example: test_user_preferences@example.com
-        phone_number:
-          type: number
-          example: 1234567890
         image:
           type: string
           format: binary
@@ -93,12 +81,6 @@ components:
         user_name:
           type: string
           example: Test User
-        email:
-          type: string
-          example: test_user_preferences@example.com
-        phone_number:
-          type: number
-          example: 1234567890
         image:
           type: string
           format: binary
@@ -145,12 +127,6 @@ components:
             user_name:
               type: string
               example: Test User
-            email:
-              type: string
-              example: example@test.com
-            phone_number:
-              type: string
-              example: +1 123 456 7890
             image:
               type: string
               format: binary

--- a/src/controllers/userPreferencesController.ts
+++ b/src/controllers/userPreferencesController.ts
@@ -15,7 +15,11 @@ export const getUserPreferences = async (req: Request, res: Response) => {
       return res.status(404).json({ message: "User Preferences not found" });
     }
     logger.info(`Fetched User Preferences for ID: ${user_settings_id}`);
-    res.status(200).json(userPreferences);
+    
+    // Remove email and phone_number if they exist in the fetched data
+    const { email, phone_number, ...filteredPreferences } = userPreferences;
+
+    res.status(200).json(filteredPreferences); // Do not return email/phone
   } catch (error: any) {
     logger.error(`Failed to fetch user preferences for userSettingsID ${ user_settings_id }:`, { 
       message: error.message,
@@ -33,8 +37,12 @@ export const fetchUserPreferences = async (req: Request, res: Response) => {
       logger.warn(`User Preferences not found for user with ID: ${req.currentUser?.pi_uid || "NULL"}`);
       return res.status(404).json({ message: "User Preferences not found" });
     }
+    
+    // Exclude email and phone_number from the response if they exist
+    const { email, phone_number, ...filteredPreferences } = currentUserPreferences;
+    
     logger.info(`Fetched User Preferences for user with ID: ${req.currentUser.pi_uid}`);
-    res.status(200).json(currentUserPreferences);
+    res.status(200).json(filteredPreferences);
 
   } catch (error: any) {
     logger.error(`Failed to fetch user preferences for userID ${ req.currentUser?.pi_uid }:`, { 
@@ -48,8 +56,8 @@ export const fetchUserPreferences = async (req: Request, res: Response) => {
 
 export const addUserPreferences = async (req: Request, res: Response) => {
   try {
-    const authUser = req.currentUser
-    const formData = req.body;
+    const authUser = req.currentUser;
+    const { email, phone_number, ...formData } = req.body; // Exclude email and phone_number
 
     if (!authUser) {
       logger.warn("No authenticated user found for user preferences.");

--- a/src/models/Seller.ts
+++ b/src/models/Seller.ts
@@ -32,6 +32,16 @@
         type: String,
         required: false,
       },
+      email: {
+        type: String,
+        required: false,
+        default: null,
+      },
+      phone_number: {
+        type: String,
+        required: false,
+        default: null,
+      },
       average_rating: {
         type: Types.Decimal128,
         required: true,

--- a/src/models/UserSettings.ts
+++ b/src/models/UserSettings.ts
@@ -15,14 +15,6 @@ const userSettingsSchema = new Schema<IUserSettings>(
       type: String,
       required: true,
     },
-    email: {
-      type: String,
-      required: false,
-    },
-    phone_number: {
-      type: String,
-      required: false,
-    },
     image: {
       type: String,
       required: false,

--- a/src/routes/seller.routes.ts
+++ b/src/routes/seller.routes.ts
@@ -35,7 +35,7 @@ import upload from "../utils/multer";
  *         address:
  *           type: string
  *           description: Address of the seller
- *           email:
+ *         email:
  *           type: string
  *           description: Seller's email address
  *         phone_number:

--- a/src/routes/seller.routes.ts
+++ b/src/routes/seller.routes.ts
@@ -35,6 +35,12 @@ import upload from "../utils/multer";
  *         address:
  *           type: string
  *           description: Address of the seller
+ *           email:
+ *           type: string
+ *           description: Seller's email address
+ *         phone_number:
+ *           type: string
+ *           description: Seller's phone number
  *         average_rating:
  *           type: object
  *           description: Average rating of the seller

--- a/src/routes/userPreferences.routes.ts
+++ b/src/routes/userPreferences.routes.ts
@@ -18,12 +18,6 @@ import upload from "../utils/multer";
  *         user_name: 
  *           type: string
  *           description: Name of the user
- *         email:
- *           type: string
- *           description: Email address of the user
- *         phone_number:
- *           type: number
- *           description: Phone number of the user
  *         image:
  *           type: string
  *           description: Image of the user

--- a/src/services/seller.service.ts
+++ b/src/services/seller.service.ts
@@ -24,8 +24,8 @@ const resolveSellerSettings = async (sellers: ISeller[]): Promise<ISellerWithSet
           trust_meter_rating: userSettings?.trust_meter_rating,
           user_name: userSettings?.user_name,
           findme: userSettings?.findme,
-          email: userSettings?.email,
-          phone_number: userSettings?.phone_number
+          email: seller?.email ?? null,
+          phone_number: seller?.phone_number ?? null,
         } as ISellerWithSettings;
       } catch (error: any) {
         logger.error(`Failed to resolve settings for sellerID ${ seller.seller_id }:`, { 
@@ -148,6 +148,8 @@ export const registerOrUpdateSeller = async (authUser: IUser, formData: any, ima
       description: formData.description || existingSeller?.description || '',
       seller_type: formData.seller_type || existingSeller?.seller_type || '',
       image: image || existingSeller?.image || '',
+      email: formData.email || existingSeller?.email || null,
+      phone_number: formData.phone_number || existingSeller?.phone_number || null,
       address: formData.address || existingSeller?.address || '',
       sell_map_center: sellMapCenter,
       order_online_enabled_pref: formData.order_online_enabled_pref || existingSeller?.order_online_enabled_pref || ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface ISeller extends Document {
   description: string;
   image?: string;
   address?: string;
+  email?: string | null,
+  phone_number?: string | null,
   average_rating: Types.Decimal128;
   sell_map_center: {
     type: 'Point';
@@ -56,7 +58,7 @@ export interface IMapCenter {
 }
 
 // Select specific fields from IUserSettings
-export type PartialUserSettings = Pick<IUserSettings, 'user_name' | 'email' | 'phone_number' | 'findme' | 'trust_meter_rating'>;
+export type PartialUserSettings = Pick<IUserSettings, 'user_name' | 'findme' | 'trust_meter_rating'>;
 
 // Combined interface representing a seller with selected user settings
 export interface ISellerWithSettings extends ISeller, PartialUserSettings {}

--- a/test/services/seller.service.spec.ts
+++ b/test/services/seller.service.spec.ts
@@ -16,76 +16,76 @@ const mockSellers = [
     name: 'Test Seller 1',
     description: 'Test Seller 1 Description',
     seller_type: SellerType.Test,
-    sell_map_center: { type: 'Point', coordinates: [-74.0060, 40.7128] }
+    sell_map_center: { type: 'Point', coordinates: [-74.0060, 40.7128] },
+    email: null,
+    phone_number: null,
   },
   {
     seller_id: '0b0b0b-0b0b-0b0b',
     name: 'Test Vendor 2',
     description: 'Test Vendor 2 Description',
     seller_type: SellerType.Inactive,
-    sell_map_center: { type: 'Point', coordinates: [-118.2437, 34.0522] }
+    sell_map_center: { type: 'Point', coordinates: [-118.2437, 34.0522] },
+    email: null,
+    phone_number: null,
   },
   {
     seller_id: '0c0c0c-0c0c-0c0c',
     name: 'Test Vendor 3',
     description: 'Test Vendor 3 Description',
     seller_type: SellerType.Active,
-    sell_map_center: { type: 'Point', coordinates: [-87.6298, 41.8781] }
+    sell_map_center: { type: 'Point', coordinates: [-87.6298, 41.8781] },
+    email: null,
+    phone_number: null,
   },
   {
     seller_id: '0d0d0d-0d0d-0d0d',
     name: 'Test Seller 4',
     description: 'Test Seller 4 Description',
     seller_type: SellerType.Inactive,
-    sell_map_center: { type: 'Point', coordinates: [-122.4194, 37.7749] }
+    sell_map_center: { type: 'Point', coordinates: [-122.4194, 37.7749] },
+    email: null,
+    phone_number: null,
   },
   {
     seller_id: '0e0e0e-0e0e-0e0e',
     name: 'Test Vendor 5',
     description: 'Test Vendor 5 Description',
     seller_type: SellerType.Test,
-    sell_map_center: { type: 'Point', coordinates: [-95.3698, 29.7604] }
-  }
+    sell_map_center: { type: 'Point', coordinates: [-95.3698, 29.7604] },
+    email: null,
+    phone_number: null,
+  },
 ] as ISeller[];
 
 const mockUserSettings = [
   {
     user_settings_id: '0a0a0a-0a0a-0a0a',
     user_name: 'Test One',
-    email: 'test-one@test.com',
-    phone_number: '111-111-1111',
     findme: 'deviceGPS',
     trust_meter_rating: TrustMeterScale.HUNDRED
   },
   {
     user_settings_id: '0b0b0b-0b0b-0b0b',
     user_name: 'Test Two',
-    email: 'test-two@test.com',
-    phone_number: '222-222-2222',
     findme: 'deviceGPS',
     trust_meter_rating: TrustMeterScale.EIGHTY
   },
   {
     user_settings_id: '0c0c0c-0c0c-0c0c',
     user_name: 'Test Three',
-    email: 'test-three@test.com',
-    phone_number: '333-333-3333',
     findme: 'deviceGPS',
     trust_meter_rating: TrustMeterScale.FIFTY
   },
   {
     user_settings_id: '0d0d0d-0d0d-0d0d',
     user_name: 'Test Four',
-    email: 'test-four@test.com',
-    phone_number: '444-444-4444',
     findme: 'deviceGPS',
     trust_meter_rating: TrustMeterScale.HUNDRED
   },
   {
     user_settings_id: '0e0e0e-0e0e-0e0e',
     user_name: 'Test Five',
-    email: 'test-five@test.com',
-    phone_number: '555-555-5555',
     findme: 'deviceGPS',
     trust_meter_rating: TrustMeterScale.EIGHTY
   }
@@ -107,8 +107,8 @@ const assertSellersWithSettings = (
         expect.objectContaining({
           ...seller,
           user_name: correspondingUserSettings?.user_name,
-          email: correspondingUserSettings?.email,
-          phone_number: correspondingUserSettings?.phone_number,
+          email: correspondingUserSettings?.email ?? null,
+          phone_number: correspondingUserSettings?.phone_number ?? null,
           findme: correspondingUserSettings?.findme,
           trust_meter_rating: correspondingUserSettings?.trust_meter_rating
         }),


### PR DESCRIPTION
In this PR, we changed the scope by moving the email and phone_number fields from the user preferences to the seller schema. These fields are now editable directly within the Seller Registration process. Both email and phone_number have been made nullable, allowing them to be optional based on the seller's input. 