### PR TITLE
Log statistics with Sanctioned Sellers Bot execution

### DIFF
--- a/src/cron/utils/sanctionUtils.ts
+++ b/src/cron/utils/sanctionUtils.ts
@@ -155,7 +155,12 @@ export const findAndRestrictSanctionedSellers = async () => {
   const results = await Promise.allSettled(tasks);
   const stats = summarizeSanctionedResults(results);
 
-  logger.info(`SanctionBot processed ${sellers.length} sellers.`);
-  logger.info(`Changed: ${stats.changed}`);
-  logger.info(`Restricted: ${stats.restricted}/ Unrestricted: ${stats.unrestricted}`);
+  logger.info('Sanction Bot Statistics', {
+    category: 'stats',
+    total_sellers_processed: sellers.length,
+    changed: stats.changed,
+    restricted: stats.restricted,
+    unrestricted: stats.unrestricted,
+    run_timestamp: new Date().toISOString()
+  });
 };

--- a/test/config/sentryConnection.spec.ts
+++ b/test/config/sentryConnection.spec.ts
@@ -1,0 +1,78 @@
+import * as Sentry from '@sentry/node';
+import { PassThrough } from 'stream';
+import { SentryTransport } from '../../src/config/sentryConnection';
+
+// Mock Sentry so no network calls are made
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+describe('SentryTransport class', () => {
+  let transport: SentryTransport;
+  const mockCallback = jest.fn();
+
+  beforeEach(() => {
+    transport = new SentryTransport({ stream: new PassThrough() });
+  });
+
+  it('should send error-level log with message to Sentry.captureMessage', () => {
+    const mockErrorMessage = 'Error log message';
+    
+    transport.log({ level: 'error', message: mockErrorMessage }, mockCallback);
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      mockErrorMessage, 
+      expect.objectContaining({
+        level: 'error',
+        tags: { category: 'uncategorized' },
+        extra: {}
+      })
+    );
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should send error-level log with Error object to Sentry.captureException', () => {
+    const mockError = new Error('Error object log message');
+
+    transport.log({ level: 'error', error: mockError }, mockCallback);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      mockError, 
+      expect.objectContaining({
+        level: 'error',
+        tags: { category: 'uncategorized' },
+        extra: {}
+      })
+    );
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should send non-error log if category is in alwaysSendCategories', () => {
+    const mockInfoMessage = "alwaysSendCategories info message"
+
+    transport.log({ level: 'info', category: 'stats', message: mockInfoMessage }, mockCallback);
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      mockInfoMessage, 
+      expect.objectContaining({
+        level: 'error', // forced to error so it bypasses prod filter
+        tags: { category: 'stats' },
+        extra: {}
+      })
+    );
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not send non-error log if category is not in alwaysSendCategories', () => {
+    const mockInfoMessage = "Non alwaysSendCategories info message"
+    
+    transport.log({ level: 'info', category: 'general', message: mockInfoMessage }, mockCallback);
+
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/cron/utils/sanctionUtils.spec.ts
+++ b/test/cron/utils/sanctionUtils.spec.ts
@@ -318,9 +318,17 @@ describe('findAndRestrictSanctionedSellers function', () => {
     expect(Seller.updateOne).toHaveBeenCalledTimes(2);
     expect(addNotification).toHaveBeenCalledTimes(2);
     expect(summarizeSanctionedResults).toHaveBeenCalledWith(expect.any(Array));
-    expect(logger.info).toHaveBeenCalledWith('SanctionBot processed 2 sellers.');
-    expect(logger.info).toHaveBeenCalledWith('Changed: 2');
-    expect(logger.info).toHaveBeenCalledWith('Restricted: 1/ Unrestricted: 1');
+    expect(logger.info).toHaveBeenCalledWith(
+      'Sanction Bot Statistics',
+      expect.objectContaining({
+        category: 'stats',
+        total_sellers_processed: 2,
+        changed: 2,
+        restricted: 1,
+        unrestricted: 1,
+        run_timestamp: expect.any(String) // since it's a timestamp string
+      })
+    );
   });
 
   it('should abort if no polygons are returned', async () => {


### PR DESCRIPTION
This PR introduces a scalable enhancement to how our recently implemented **Sanction Bot** logs sanctioned seller stats to our logging platform, Sentry.  Currently, the Sentry logging level in production is set to `error` to stay within the free-tier event quota and avoid flooding with low-severity logs.  However, we still need to track important bot statistics (e.g., number of sellers processed, restricted, unrestricted, etc.) for transparency and monitoring.

The custom Winston SentryTransport has been adjusted as follows →
- Automatically tags logs with a category (e.g., stats) to enable filtering and alerting in Sentry.
- Forces logs with specific categories to be sent to Sentry at error level, regardless of global log level settings.
- Supports easy future addition of other specialized categories.

With this change, we can also leverage webhook integration to forward categorized logs to a designated Discord channel for live monitoring.

**[see commits]**